### PR TITLE
It works, but still hanging with infinite receive timeout at the end

### DIFF
--- a/search_jrnl.py
+++ b/search_jrnl.py
@@ -4,17 +4,16 @@ import os
 
 qi = win32com.client.Dispatch("MSMQ.MSMQQueueInfo")
 computer_name = os.getenv('COMPUTERNAME')
-qi.FormatName="direct=os:"+computer_name+"\\private$\\pythontest;journal"
-strFind = "{report:0}"
+qi.FormatName="direct=os:"+computer_name+"\\private$\\Tasks;journal"
+strFind = "{report:9}"
+strOutputPath = r"Output.txt"
 
 from constants import *
 queue = qi.Open(MQ_PEEK_ACCESS, MQ_DENY_NONE)
 
 while True:
 
-
-    msg = queue.PeekCurrent(ReceiveTimeout='1000')
-
+    msg = queue.PeekCurrent(ReceiveTimeout = 10000)
 
     while msg: 
 
@@ -22,9 +21,10 @@ while True:
         print( msg.Body )
         #test Body for search string and write it out to disk
         if strFind in msg.Body:
-            with open("Output.txt", "w") as text_file:
-                text_file.write("\n{}".format(msg.Body))
-        msg = queue.PeekNext(ReceiveTimeout='1000')
+            with open(strOutputPath, "w") as text_file:
+                text_file.write("{}\n{}".format(msg.SentTime, msg.Body))
+
+        msg = queue.PeekNext(ReceiveTimeout = 10000)
 
     break
 

--- a/send.py
+++ b/send.py
@@ -3,7 +3,7 @@ import os
 
 qi = win32com.client.Dispatch("MSMQ.MSMQQueueInfo")
 computer_name = os.getenv('COMPUTERNAME')
-qi.FormatName="direct=os:"+computer_name+"\\private$\\pythontest"
+qi.FormatName="direct=os:"+computer_name+"\\private$\\Tasks"
 
 from constants import *
 queue = qi.Open(MQ_SEND_ACCESS, MQ_DENY_NONE)


### PR DESCRIPTION
search_jrnl.py will search the journal for messages whose body contents
contain a certain string and write that out to al file with the sent time.  There is one major issue where the PeekNext and PeekCurrent methods are not respecting the ReceiveTimeout argument and waiting indefinitely for messages to enter the journal...